### PR TITLE
Add teleport GUI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This plugin brings a new dimension to teleportation, providing seamless and effi
 | `/tp <player>`        | -            | `bungeetp.tp`        | Teleport to another player                          |
 | `/tpahere <player>`   | -            | `bungeetp.tpahere`   | Request another player to teleport to your location |
 | `/tphere <player>`    | `/s <player>`| `bungeetp.tphere`    | Teleport another player to your location (alias: /s)|
+| `/tpgui`              | -            | `bungeetp.tpgui`     | Open a GUI listing online players for quick teleport |
 | `/tpaccept`           | -            | `bungeetp.accept`    | Accept a teleport request                           |
 | `/tpcancel`           | -            | `bungeetp.cancel`    | Cancel a teleport request                           |
 | `/tpdenyall`          | -            | `bungeetp.deny.all`  | Deny all pending teleport requests                  |

--- a/bridge/common/src/main/java/net/savagedev/tpa/bridge/messenger/BungeeTpBridgeMessenger.java
+++ b/bridge/common/src/main/java/net/savagedev/tpa/bridge/messenger/BungeeTpBridgeMessenger.java
@@ -19,6 +19,7 @@ import net.savagedev.tpa.common.messaging.messages.MessageEconomyResponse;
 import net.savagedev.tpa.common.messaging.messages.MessageEconomyWithdrawRequest;
 import net.savagedev.tpa.common.messaging.messages.MessageRequestTeleportCoords;
 import net.savagedev.tpa.common.messaging.messages.MessageRequestTeleportPlayer;
+import net.savagedev.tpa.common.messaging.messages.MessageOpenTeleportGui;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -36,6 +37,7 @@ public abstract class BungeeTpBridgeMessenger<T> extends AbstractMessenger<T> {
         DECODER_FUNCTIONS.put(MessageEconomyDepositRequest.class.getSimpleName(), MessageEconomyDepositRequest::deserialize);
         DECODER_FUNCTIONS.put(MessageBasicServerInfoRequest.class.getSimpleName(), MessageBasicServerInfoRequest::deserialize);
         DECODER_FUNCTIONS.put(MessageCurrencyFormatRequest.class.getSimpleName(), MessageCurrencyFormatRequest::deserialize);
+        DECODER_FUNCTIONS.put(MessageOpenTeleportGui.class.getSimpleName(), MessageOpenTeleportGui::deserialize);
     }
 
     private final BungeeTpBridgePlatform platform;

--- a/bridge/spigot/build.gradle.kts
+++ b/bridge/spigot/build.gradle.kts
@@ -6,16 +6,15 @@ group = project.parent?.group!!
 version = project.parent?.version!!
 
 repositories {
-    maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots")
-
-    maven("https://repo.essentialsx.net/snapshots/")
+    maven("https://repo.papermc.io/repository/maven-public/")
+    maven("https://repo.essentialsx.net/releases/")
     maven("https://jitpack.io")
 }
 
 dependencies {
-    compileOnly("org.spigotmc:spigot-api:1.20-R0.1-SNAPSHOT")
+    compileOnly("org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT")
 
-    compileOnly("net.essentialsx:EssentialsX:2.21.0-SNAPSHOT") {
+    compileOnly("net.essentialsx:EssentialsX:2.22.0") {
         exclude("io.papermc")
     }
     compileOnly("com.github.LeonMangler:SuperVanish:6.2.18-3")

--- a/bridge/spigot/src/main/java/net/savagedev/tpa/spigot/BungeeTpSpigotPlugin.java
+++ b/bridge/spigot/src/main/java/net/savagedev/tpa/spigot/BungeeTpSpigotPlugin.java
@@ -14,6 +14,8 @@ import net.savagedev.tpa.spigot.hook.vanish.SuperVanishPluginHook;
 import net.savagedev.tpa.spigot.listeners.ConnectionListener;
 import net.savagedev.tpa.spigot.messenger.SpigotPluginMessenger;
 import net.savagedev.tpa.spigot.model.SpigotPlayer;
+import net.savagedev.tpa.spigot.gui.TeleportGuiListener;
+import net.savagedev.tpa.spigot.gui.TeleportGuiManager;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
@@ -35,10 +37,13 @@ public class BungeeTpSpigotPlugin extends JavaPlugin implements BungeeTpBridgePl
 
     private AbstractVanishHook vanishProvider;
     private AbstractEconomyHook economyHook;
+    private TeleportGuiManager guiManager;
 
     @Override
     public void onEnable() {
+        this.guiManager = new TeleportGuiManager(this);
         this.getServer().getPluginManager().registerEvents(new ConnectionListener(this), this);
+        this.getServer().getPluginManager().registerEvents(new TeleportGuiListener(this.guiManager), this);
         this.plugin.enable();
 
         this.hookEconomy();
@@ -151,5 +156,12 @@ public class BungeeTpSpigotPlugin extends JavaPlugin implements BungeeTpBridgePl
     @Override
     public String getOfflineUsername(UUID uuid) {
         return this.getServer().getOfflinePlayer(uuid).getName();
+    }
+
+    public void openTeleportGui(UUID uuid, Map<UUID, String> players) {
+        Player player = this.getServer().getPlayer(uuid);
+        if (player != null) {
+            this.guiManager.openGui(player, players);
+        }
     }
 }

--- a/bridge/spigot/src/main/java/net/savagedev/tpa/spigot/gui/TeleportGuiListener.java
+++ b/bridge/spigot/src/main/java/net/savagedev/tpa/spigot/gui/TeleportGuiListener.java
@@ -1,0 +1,43 @@
+package net.savagedev.tpa.spigot.gui;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+
+import java.util.Map;
+
+public class TeleportGuiListener implements Listener {
+    private final TeleportGuiManager manager;
+
+    public TeleportGuiListener(TeleportGuiManager manager) {
+        this.manager = manager;
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player)) {
+            return;
+        }
+        Player player = (Player) event.getWhoClicked();
+        Map<Integer, String> map = this.manager.getTargets(player);
+        if (map == null) {
+            return;
+        }
+        event.setCancelled(true);
+        String target = map.get(event.getRawSlot());
+        if (target != null) {
+            player.closeInventory();
+            player.chat("/tp " + target);
+            this.manager.close(player);
+        }
+    }
+
+    @EventHandler
+    public void onClose(InventoryCloseEvent event) {
+        if (event.getPlayer() instanceof Player) {
+            this.manager.close((Player) event.getPlayer());
+        }
+    }
+}

--- a/bridge/spigot/src/main/java/net/savagedev/tpa/spigot/gui/TeleportGuiManager.java
+++ b/bridge/spigot/src/main/java/net/savagedev/tpa/spigot/gui/TeleportGuiManager.java
@@ -1,0 +1,54 @@
+package net.savagedev.tpa.spigot.gui;
+
+import net.savagedev.tpa.spigot.BungeeTpSpigotPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class TeleportGuiManager {
+    private final BungeeTpSpigotPlugin plugin;
+    private final Map<UUID, Map<Integer, String>> targetMap = new HashMap<>();
+
+    public TeleportGuiManager(BungeeTpSpigotPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void openGui(Player player, Map<UUID, String> targets) {
+        int size = ((targets.size() - 1) / 9 + 1) * 9;
+        Inventory inv = Bukkit.createInventory(null, size, ChatColor.GREEN + "Teleport");
+        Map<Integer, String> slotMap = new HashMap<>();
+        List<Map.Entry<UUID, String>> entries = new ArrayList<>(targets.entrySet());
+        for (int i = 0; i < entries.size(); i++) {
+            Map.Entry<UUID, String> entry = entries.get(i);
+            ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+            SkullMeta meta = (SkullMeta) head.getItemMeta();
+            OfflinePlayer off = Bukkit.getOfflinePlayer(entry.getKey());
+            meta.setOwningPlayer(off);
+            meta.setDisplayName(ChatColor.YELLOW + entry.getValue());
+            head.setItemMeta(meta);
+            inv.setItem(i, head);
+            slotMap.put(i, entry.getValue());
+        }
+        this.targetMap.put(player.getUniqueId(), slotMap);
+        player.openInventory(inv);
+    }
+
+    public Map<Integer, String> getTargets(Player player) {
+        return this.targetMap.get(player.getUniqueId());
+    }
+
+    public void close(Player player) {
+        this.targetMap.remove(player.getUniqueId());
+    }
+}

--- a/bridge/spigot/src/main/java/net/savagedev/tpa/spigot/messenger/SpigotPluginMessenger.java
+++ b/bridge/spigot/src/main/java/net/savagedev/tpa/spigot/messenger/SpigotPluginMessenger.java
@@ -4,6 +4,7 @@ import net.savagedev.tpa.bridge.messenger.BungeeTpBridgeMessenger;
 import net.savagedev.tpa.bridge.model.BungeeTpPlayer;
 import net.savagedev.tpa.common.messaging.ChannelConstants;
 import net.savagedev.tpa.common.messaging.messages.Message;
+import net.savagedev.tpa.common.messaging.messages.MessageOpenTeleportGui;
 import net.savagedev.tpa.spigot.BungeeTpSpigotPlugin;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.messaging.Messenger;
@@ -38,6 +39,16 @@ public class SpigotPluginMessenger extends BungeeTpBridgeMessenger<BungeeTpPlaye
     @Override
     public void onPluginMessageReceived(@Nonnull String channel, @Nonnull Player player, @Nonnull byte[] bytes) {
         super.handleIncomingMessage(null, channel, bytes);
+    }
+
+    @Override
+    public void handleIncomingMessage(Message message) {
+        if (message instanceof MessageOpenTeleportGui) {
+            MessageOpenTeleportGui gui = (MessageOpenTeleportGui) message;
+            this.plugin.openTeleportGui(gui.getRequester(), gui.getPlayers());
+            return;
+        }
+        super.handleIncomingMessage(message);
     }
 
     @Override

--- a/common/src/main/java/net/savagedev/tpa/common/messaging/messages/MessageOpenTeleportGui.java
+++ b/common/src/main/java/net/savagedev/tpa/common/messaging/messages/MessageOpenTeleportGui.java
@@ -1,0 +1,63 @@
+package net.savagedev.tpa.common.messaging.messages;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class MessageOpenTeleportGui extends Message {
+    public static MessageOpenTeleportGui deserialize(JsonObject object) {
+        final long reqMsb = object.get("req_msb").getAsLong();
+        final long reqLsb = object.get("req_lsb").getAsLong();
+        UUID requester = new UUID(reqMsb, reqLsb);
+
+        Map<UUID, String> players = new HashMap<>();
+        JsonArray arr = object.getAsJsonArray("players");
+        for (JsonElement element : arr) {
+            JsonObject o = element.getAsJsonObject();
+            long msb = o.get("msb").getAsLong();
+            long lsb = o.get("lsb").getAsLong();
+            String name = o.get("name").getAsString();
+            players.put(new UUID(msb, lsb), name);
+        }
+        return new MessageOpenTeleportGui(requester, players);
+    }
+
+    private final UUID requester;
+    private final Map<UUID, String> players = new HashMap<>();
+
+    public MessageOpenTeleportGui(UUID requester, Map<UUID, String> players) {
+        this.requester = requester;
+        if (players != null) {
+            this.players.putAll(players);
+        }
+    }
+
+    public UUID getRequester() {
+        return this.requester;
+    }
+
+    public Map<UUID, String> getPlayers() {
+        return this.players;
+    }
+
+    @Override
+    protected JsonObject asJsonObject() {
+        JsonObject object = new JsonObject();
+        object.addProperty("req_msb", this.requester.getMostSignificantBits());
+        object.addProperty("req_lsb", this.requester.getLeastSignificantBits());
+        JsonArray arr = new JsonArray();
+        for (Map.Entry<UUID, String> entry : this.players.entrySet()) {
+            JsonObject o = new JsonObject();
+            o.addProperty("msb", entry.getKey().getMostSignificantBits());
+            o.addProperty("lsb", entry.getKey().getLeastSignificantBits());
+            o.addProperty("name", entry.getValue());
+            arr.add(o);
+        }
+        object.add("players", arr);
+        return object;
+    }
+}

--- a/plugin/common/src/main/java/net/savagedev/tpa/plugin/BungeeTpPlugin.java
+++ b/plugin/common/src/main/java/net/savagedev/tpa/plugin/BungeeTpPlugin.java
@@ -8,6 +8,7 @@ import net.savagedev.tpa.plugin.commands.TpDenyCommand;
 import net.savagedev.tpa.plugin.commands.TpHereCommand;
 import net.savagedev.tpa.plugin.commands.TpaCommand;
 import net.savagedev.tpa.plugin.commands.TpaHereCommand;
+import net.savagedev.tpa.plugin.commands.TpGuiCommand;
 import net.savagedev.tpa.plugin.commands.admin.BungeeTpAdminCommand;
 import net.savagedev.tpa.plugin.commands.admin.ReloadCommand;
 import net.savagedev.tpa.plugin.commands.admin.ServerInfoCommand;
@@ -122,6 +123,7 @@ public class BungeeTpPlugin {
         this.platform.registerCommand(new TpDenyAllCommand(this), "tpdenyall", "bungeetp.deny.all");
         this.platform.registerCommand(new TpDenyCommand(this), "tpdeny", "bungeetp.deny");
         this.platform.registerCommand(new TpHereCommand(this), "tphere", "bungeetp.tphere", "s");
+        this.platform.registerCommand(new TpGuiCommand(this), "tpgui", "bungeetp.tpgui");
         // Putting this off until I have the time to write a more robust storage solution.
         // this.platform.registerCommand(new TpToggleCommand(), "tptoggle", "bungeetp.toggle");
     }

--- a/plugin/common/src/main/java/net/savagedev/tpa/plugin/commands/TpGuiCommand.java
+++ b/plugin/common/src/main/java/net/savagedev/tpa/plugin/commands/TpGuiCommand.java
@@ -1,0 +1,28 @@
+package net.savagedev.tpa.plugin.commands;
+
+import net.savagedev.tpa.common.messaging.messages.MessageOpenTeleportGui;
+import net.savagedev.tpa.plugin.BungeeTpPlugin;
+import net.savagedev.tpa.plugin.command.BungeeTpCommand;
+import net.savagedev.tpa.plugin.model.player.ProxyPlayer;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class TpGuiCommand implements BungeeTpCommand {
+    private final BungeeTpPlugin plugin;
+
+    public TpGuiCommand(BungeeTpPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void execute(ProxyPlayer<?, ?> player, String[] args) {
+        Map<UUID, String> players = this.plugin.getOnlinePlayers().stream()
+                .filter(ProxyPlayer::notHidden)
+                .filter(p -> !p.getUniqueId().equals(player.getUniqueId()))
+                .collect(Collectors.toMap(ProxyPlayer::getUniqueId, ProxyPlayer::getName));
+        this.plugin.getPlatform().getMessenger().sendData(player.getCurrentServer(),
+                new MessageOpenTeleportGui(player.getUniqueId(), players));
+    }
+}


### PR DESCRIPTION
## Summary
- add `MessageOpenTeleportGui` for proxy→server inventory requests
- register new `tpgui` command
- add Spigot-side GUI manager and listener
- open GUI on message receive
- document `/tpgui` in README
- update Spigot and EssentialsX dependencies to public repos

## Testing
- `sh gradlew test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6841ab13bd1c8329ab1cb75120cc1c9a